### PR TITLE
Add release notes for CI and public comment stages

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,3 +1,25 @@
+{% if site.data.info.releaselabel == 'ci-build' %}
+<div style="width: 65%">
+    <blockquote class="stu-note">
+    <p>Cet Implementation Guide n'est pas la version courante, il s'agit de la version en intégration continue soumise à des changements fréquents uniquement destinée à suivre les travaux en cours. La version courante sera accessible via l'URL canonique suite à la première release : http://hl7.fr/fhir/fr/preadmission</p>
+    </blockquote>
+</div>
+{% endif %}
+
+
+{% if site.data.info.releaselabel == 'public-comment' %}
+<div style="width: 65%">
+<blockquote class="stu-note">
+<p>
+  <b>Attention !</b>
+  <br>
+ Cet Implementation Guide est actuellement en concertation. La version courante est accessible à l'adresse : http://hl7.fr/fhir/fr/preadmission
+</p>
+</blockquote>
+</div>
+{% endif %}
+
+
 ### Guide d’Implémentation FHIR – Pré-admission Hospitalière en Ligne
 
 Bienvenue dans le guide d'implémentation FHIR pour la pré-admission hospitalière en ligne. Ce document est structuré en plusieurs sections pour faciliter la compréhension et l'intégration des spécifications de notre Interopérabilité.


### PR DESCRIPTION
Added conditional blocks for release labels to display notes regarding the implementation guide's status.

## Description des changements

* [changement 1]
* [changement 2]
* ...

## Preview

https://Interop-Sante.github.io/IG-fhir-hl7.fhir.fr.preadmission/[ajouter_nom_de_la_branche]/ig 
